### PR TITLE
replace brackets in cap task descriptions

### DIFF
--- a/oh-my-zsh/custom/plugins/capistrano_custom/_capistrano_custom
+++ b/oh-my-zsh/custom/plugins/capistrano_custom/_capistrano_custom
@@ -18,7 +18,7 @@ _arguments -C \
 _cap_tasks() {
   if [[ -f config/deploy.rb || -f Capfile ]]; then
     if [[ ! -f .cap_tasks~ ]]; then
-      shipit -v --tasks | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
+      shipit -v --tasks | sed 's/\(\[\)\(.*\)\(\]\)/\2:/' | awk '{command=$2; $1=$2=$3=""; gsub(/^[ \t\r\n]+/, "", $0); gsub(":", "\\:", command); print command"["$0"]"}' > .cap_tasks~
     fi
 
     OLD_IFS=$IFS


### PR DESCRIPTION
older versions of capistrano contain descriptions that break the autocompleter:

https://github.com/capistrano/capistrano/blob/v2.15.5/lib/capistrano/recipes/deploy/assets.rb#L84-L87
